### PR TITLE
manifest: Add guard for AOSP hardware/qcom

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -61,7 +61,7 @@
   <project path="hardware/qcom-caf/bootctrl" name="LineageOS/android_hardware_qcom_bootctrl" groups="qcom,pdk-qcom" revision="lineage-18.1-caf" />
   <project path="hardware/qcom-caf/common" name="LineageOS/android_hardware_qcom-caf_common" groups="qcom,pdk-qcom" >
     <!-- add guard for AOSP hardware/qcom dir -->
-    <!--<linkfile src="os_pickup_aosp.mk" dest="hardware/qcom/Android.mk" />-->
+    <linkfile src="os_pickup_aosp.mk" dest="hardware/qcom/Android.mk" />
     <!-- for AOSP sdm845 and sm8150, we override os_pickup.mk -->
     <!--<linkfile src="os_pickup.mk" dest="hardware/qcom/sdm845/Android.mk" />-->
     <!--<linkfile src="os_pickup.mk" dest="hardware/qcom/sm8150/Android.mk" />-->


### PR DESCRIPTION
This is needed for devices which are using the BOARD_USES_QCOM_HARDWARE flag. Without it, the build does fail on devices which are using this and have for example the GPS source included in their device tree.